### PR TITLE
[Don't merge] Try to receive life-cycle notifications

### DIFF
--- a/Sessions.xcodeproj/project.pbxproj
+++ b/Sessions.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		503750DC2518257400F8C248 /* NotificationReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503750DB2518257400F8C248 /* NotificationReceiver.swift */; };
 		5040E10B24CAC6A5002DF8F9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5040E10A24CAC6A5002DF8F9 /* SceneDelegate.swift */; };
 		5096033124C87F79000DA7AD /* SessionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5096033024C87F79000DA7AD /* SessionDetailViewController.swift */; };
 		5096033324C9253E000DA7AD /* initial.realm in Resources */ = {isa = PBXBuildFile; fileRef = 5096033224C9251D000DA7AD /* initial.realm */; };
@@ -38,6 +39,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		503750DB2518257400F8C248 /* NotificationReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationReceiver.swift; sourceTree = "<group>"; };
 		5040E10A24CAC6A5002DF8F9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		5096033024C87F79000DA7AD /* SessionDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDetailViewController.swift; sourceTree = "<group>"; };
 		5096033224C9251D000DA7AD /* initial.realm */ = {isa = PBXFileReference; lastKnownFileType = file; path = initial.realm; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 				50C5E89324C4745100EA36A9 /* Info.plist */,
 				50C5E8A224C47D1900EA36A9 /* Model.swift */,
 				5096033224C9251D000DA7AD /* initial.realm */,
+				503750DB2518257400F8C248 /* NotificationReceiver.swift */,
 			);
 			path = Sessions;
 			sourceTree = "<group>";
@@ -210,6 +213,7 @@
 				50C5E88624C4744900EA36A9 /* AppDelegate.swift in Sources */,
 				5096033124C87F79000DA7AD /* SessionDetailViewController.swift in Sources */,
 				50C5E8A324C47D1900EA36A9 /* Model.swift in Sources */,
+				503750DC2518257400F8C248 /* NotificationReceiver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sessions/AppDelegate.swift
+++ b/Sessions/AppDelegate.swift
@@ -27,6 +27,8 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    let notificationReceiver = NotificationReceiver()
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -36,5 +38,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        print("[appDelegate] applicationWillEnterForeground")
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        print("[appDelegate] applicationDidBecomeActive")
+    }
+    
+    func applicationWillResignActive(_ application: UIApplication) {
+        print("[appDelegate] applicationWillResignActive")
+    }
+    
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        print("[appDelegate] applicationDidEnterBackground")
     }
 }

--- a/Sessions/NotificationReceiver.swift
+++ b/Sessions/NotificationReceiver.swift
@@ -1,0 +1,78 @@
+//
+// NotificationReceiver.swift
+// Sessions
+//
+// Copyright (c) 2020 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import UIKit
+
+@objc class NotificationReceiver: NSObject {
+    override init() {
+        super.init()
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(sceneWillEnterForeground), name: UIScene.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(sceneDidActivate), name: UIScene.didActivateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(sceneWillDeactivate), name: UIScene.willDeactivateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(sceneDidEnterBackground), name: UIScene.didEnterBackgroundNotification, object: nil)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    @objc func appWillEnterForeground() {
+        print("<app> willEnterForeground Notification")
+    }
+
+    @objc func appDidBecomeActive() {
+        print("<app> didBecomeActive Notification")
+    }
+
+    @objc func appWillResignActive() {
+        print("<app> willResignActive Notification")
+    }
+    
+    @objc func appDidEnterBackground() {
+        print("<app> didEnterBackground Notification")
+    }
+    
+    @objc func sceneWillEnterForeground() {
+        print("<scene> sceneEnterForeground Notification")
+    }
+
+    @objc func sceneDidActivate() {
+        print("<scene> didActivate Notification")
+    }
+
+    @objc func sceneWillDeactivate() {
+        print("<scene> willDeactivate Notification")
+    }
+    
+    @objc func sceneDidEnterBackground() {
+        print("<scene> didEnterBackground Notification")
+    }
+}

--- a/Sessions/SceneDelegate.swift
+++ b/Sessions/SceneDelegate.swift
@@ -73,28 +73,32 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        print("[sceneDelegate] sceneDidBecomeActive")
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
+        print("[sceneDelegate] sceneWillResignActive")
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        print("[sceneDelegate] sceneWillEnterForeground")
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+        print("[sceneDelegate] sceneDidEnterBackground")
     }
 
     func stateRestorationActivity(for scene: UIScene) -> NSUserActivity? {
         return scene.userActivity
     }
-    
+
     func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
         setupViewController(for: shortcutItem)
         completionHandler(true)


### PR DESCRIPTION
The beginning of the story is [this](https://twitter.com/takasek/status/1307568882496933889).

With this PR, logs below ware printed out to console. (I tried it with iPadOS 11.6 on simulator)

When app launches,

```
[sceneDelegate] sceneWillEnterForeground
<scene> sceneEnterForeground Notification
<app> willEnterForeground Notification
[sceneDelegate] sceneDidBecomeActive
<scene> didActivate Notification
<app> didBecomeActive Notification
```

Then show app-switcher,

```
[sceneDelegate] sceneWillResignActive
<scene> willDeactivate Notification
<app> willResignActive Notification
```

Switch to another app,

```
[sceneDelegate] sceneDidEnterBackground
<scene> didEnterBackground Notification
<app> didEnterBackground Notification
```

Switch to this app again,

```
[sceneDelegate] sceneWillEnterForeground
<scene> sceneEnterForeground Notification
<app> willEnterForeground Notification
[sceneDelegate] sceneDidBecomeActive
<scene> didActivate Notification
<app> didBecomeActive Notification
```

Show Dock and do "Show All Windows" from dock icon,

```
[sceneDelegate] sceneWillResignActive
<scene> willDeactivate Notification
<app> willResignActive Notification
```

Select another scene,

```
[sceneDelegate] sceneWillEnterForeground
<scene> sceneEnterForeground Notification
[sceneDelegate] sceneDidBecomeActive
<scene> didActivate Notification
<app> didBecomeActive Notification
[sceneDelegate] sceneDidEnterBackground
<scene> didEnterBackground Notification
```

Summarize the above:
- Methods in `AppDelegate`, e.g. `applicationDidBecomeActive`,  was never called.  
- Notifications in `UIApplication`, e.g. `UIApplication.didBecomeActiveNotification` was sent!! 😲 
- Notifications in `UIScene`, e.g. `UIScene.didActivateNotification` was sent.
- Note that when switching one scene to another scene in same app, `UIApplication.willEnterForegroundNotification` and `UIApplication.didEnterBackgroundNotification` were not sent contrary to that corresponding scene event was sent. ⚠️ 